### PR TITLE
Fix issues with Vagrant files

### DIFF
--- a/pipeline/s1-create-skeleton/env-prod/Vagrantfile
+++ b/pipeline/s1-create-skeleton/env-prod/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.11"
+  config.vm.network "private_network", ip: "192.168.56.11"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/pipeline/s1-create-skeleton/env-stage/Vagrantfile
+++ b/pipeline/s1-create-skeleton/env-stage/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.56.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/pipeline/s2-automate-build/integration-server/Vagrantfile
+++ b/pipeline/s2-automate-build/integration-server/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.hostname = "integration-server"
   
   ENV['LC_ALL']="en_US.UTF-8"
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.9"
+  config.vm.network "private_network", ip: "192.168.56.9"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -71,7 +71,6 @@ Vagrant.configure("2") do |config|
   
   config.vm.provision "shell", inline: <<-SHELL
      	sudo apt-get update
-     	sudo apt-get install --yes python
      	# apt-get install -y default-jre
   	# apt-get install -y apache2
    	SHELL

--- a/pipeline/s2-automate-build/integration-server/Vagrantfile
+++ b/pipeline/s2-automate-build/integration-server/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
    	  # vb.gui = true
   
      # Customize the amount of memory on the VM:
-        vb.memory = "4096"
+        vb.memory = 5 * 1024
     	vb.cpus = 4
    end
   #

--- a/pipeline/s2-automate-build/integration-server/playbook/roles/docker/tasks/main.yml
+++ b/pipeline/s2-automate-build/integration-server/playbook/roles/docker/tasks/main.yml
@@ -4,7 +4,6 @@
   apt:
     update_cache: yes
 
-
 - name: Safe system upgrade via aptitude.
   apt: 
     upgrade: safe
@@ -18,20 +17,18 @@
     - apt-transport-https
     - ca-certificates
     - curl
-    - gnupg2
     - software-properties-common
 
-- name:  Add Docker key to the list of trusted APT keys.
-  shell: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-  args:
-    executable: /bin/bash
-    warn: False
 
-  
-- name: Add docker to APT repo. 
-  shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  #ignore_errors: True    
+- name: Add Docker GPG apt Key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
 
+- name: Add Docker Repository
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu focal stable
+    state: present
 
 - name: Update repositories cache. 
   apt:
@@ -46,6 +43,8 @@
     - docker-ce 
     - docker-ce-cli
     - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin
     
     
 - name: Add users to docker group. 

--- a/provision/Vagrantfile
+++ b/provision/Vagrantfile
@@ -2,7 +2,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.hostname = "devops-vm"
   config.vm.network :private_network, ip: "192.168.58.111"
 
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   config.vm.provision "shell", inline: <<-SHELL
      	sudo apt-get update
-     	sudo apt-get install --yes python
      	sudo apt-get install dpkg     	
    	SHELL
    


### PR DESCRIPTION
This PR addresses 2 fixes:
1. [s1-create-skeleton](https://github.com/acapozucca/devops/tree/master/pipeline/s1-create-skeleton)
  - The private network IP was not valid.
2. [provision](https://github.com/acapozucca/devops/tree/master/provision)
  - The vagrant box was using `ubuntu xenial64` which is very old, creating problem with newer versions of Ansible due to python versions